### PR TITLE
Cookies are expected to be convertable to byte-streams.

### DIFF
--- a/web_printscreen_zb/controllers.py
+++ b/web_printscreen_zb/controllers.py
@@ -179,6 +179,6 @@ class ZbPdfExport(ExportPdf):
                                  headers=[('Content-Disposition',
                                            'attachment; filename=PDF Export'),
                                           ('Content-Type', self.content_type)],
-                                 cookies={'fileToken': int(token)})
+                                 cookies={'fileToken': token})
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:


### PR DESCRIPTION
werkzeug.wrappers.set_cookie expects the "value" parameter to be a string, and not an int.

This fixes: https://github.com/zbeanz/openerp-7-web-addons/issues/4
